### PR TITLE
Adding delete device playbook/role

### DIFF
--- a/playbooks/nso_delete_devices.yml
+++ b/playbooks/nso_delete_devices.yml
@@ -1,0 +1,12 @@
+- name: Delete Hosts from NSO
+  hosts: network
+  connection: local
+  gather_facts: no
+  roles:
+    - ciscops.mdd.nso
+  tasks:
+    - block:
+      - name: Delete Host From NSO
+        include_role:
+          name: ciscops.mdd.nso
+          tasks_from: delete_host

--- a/roles/nso/tasks/delete_host.yml
+++ b/roles/nso/tasks/delete_host.yml
@@ -1,0 +1,10 @@
+- name: Delete Host From NSO
+  cisco.nso.nso_config:
+    url: "{{ nso_url }}"
+    username: "{{ nso_username }}"
+    password: "{{ nso_password }}"
+    data:
+      tailf-ncs:devices:
+        device:
+        - name: "{{ device_name | default(inventory_hostname) }}"
+          __state: absent


### PR DESCRIPTION
If re-using an existing NSO for CI, need the ability to delete devices from NSO and start from scratch.  This PR adds that capability.