### PR TITLE
Updates/improvements for DevNet NSO sandbox and customer environments

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,67 @@
+# -*- mode: yaml -*-
+# vim:ts=2:sw=2:ai:si:syntax=yaml
+#
+# yamllint configuration directives
+# Project Homepage: https://github.com/adrienverge/yamllint
+#
+# Overriding rules in files:
+# http://yamllint.readthedocs.io/en/latest/disable_with_comments.html
+---
+extends: default
+
+# Rules documentation: http://yamllint.readthedocs.io/en/latest/rules.html
+rules:
+
+  braces:
+    # Defaults
+    # min-spaces-inside: 0
+    # max-spaces-inside: 0
+
+    # Keeping 0 min-spaces to not error on empty collection definitions
+    min-spaces-inside: 0
+    # Allowing one space inside braces to improve code readability
+    max-spaces-inside: 1
+
+  brackets:
+    # Defaults
+    # min-spaces-inside: 0
+    # max-spaces-inside: 0
+
+    # Keeping 0 min-spaces to not error on empty collection definitions
+    min-spaces-inside: 0
+    # Allowing one space inside braces to improve code readability
+    max-spaces-inside: 1
+
+  comments:
+    # Defaults
+    # level: warning
+    # require-starting-space: true
+    # min-spaces-from-content: 2
+
+    # Disabling to allow for code comment blocks and #!/usr/bin/ansible-playbook
+    require-starting-space: false
+
+  indentation:
+    # Defaults
+    # spaces: consistent
+    # indent-sequences: true
+    # check-multi-line-strings: false
+
+    # Requiring 2 space indentation
+    spaces: 2
+    # Requiring consistent indentation within a file, either indented or not
+    indent-sequences: consistent
+
+  # Disabling due to copious amounts of long lines in the code which would
+  # require a code style change to resolve
+  line-length: disable
+    # Defaults
+    # max: 80
+    # allow-non-breakable-words: true
+    # allow-non-breakable-inline-mappings: false
+
+  # Disabling due to copious amounts of truthy warnings in the code which would
+  # require a code style change to resolve
+  truthy: disable
+    # Defaults
+    # level: warning

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help: ## Display help
 	printf "\033[36m%-30s\033[0m %s\n", $$1, $$NF \
 	}' $(MAKEFILE_LIST)
 
-all: test build publish ## Setup python-viptela env and run tests
+all: clean build test ## Setup python-viptela env and run tests
 
 $(VENV): $(VENV_BIN)/activate ## Build virtual environment
 

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ciscops
 name: mdd
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.2.6
+version: 1.2.5
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ciscops
 name: mdd
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.2.5
+version: 1.2.6
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ciscops
 name: mdd
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.2.4
+version: 1.2.5
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/playbooks/cml_update_lab.yml
+++ b/playbooks/cml_update_lab.yml
@@ -8,6 +8,7 @@
   vars:
     start_from: 2
     layout: kamada_kawai
+    inventory_dir: inventory
   tasks:
 
     - name: Get CDP data
@@ -48,5 +49,5 @@
     - name: Create mapping file
       copy:
         content: "{{ {'all': {'hosts': results.mappings}} | to_nice_yaml(indent=2,sort_keys=False) }}"
-        dest: "{{ lookup('env', 'PWD') }}/inventory/cml_intf_map.yml"
+        dest: "{{ lookup('env', 'PWD') }}/{{ inventory_dir }}/cml_intf_map.yml"
       run_once: yes

--- a/playbooks/cml_update_lab.yml
+++ b/playbooks/cml_update_lab.yml
@@ -44,8 +44,8 @@
         tags: []
     # Default interface mapping for CML
     default_cml_default_mappings:
-      Loopback(\\d+): Loopback\\1
-      Vlan(\\d+): Vlan\\1
+      Loopback(\d+): Loopback\1
+      Vlan(\d+): Vlan\1
   tasks:
 
     - name: Get CDP data

--- a/playbooks/cml_update_lab.yml
+++ b/playbooks/cml_update_lab.yml
@@ -1,0 +1,52 @@
+---
+- name: Get CDP Data for Devices
+  hosts: network
+  connection: local
+  gather_facts: no
+  roles:
+    - ciscops.mdd.nso
+  vars:
+    start_from: 2
+    layout: kamada_kawai
+  tasks:
+
+    - name: Get CDP data
+      include_role:
+        name: ciscops.mdd.nso
+        tasks_from: exec_command
+      vars:
+        nso_exec_command: show cdp neighbors    
+
+    - set_fact:
+        cdp_data: "{{ {'hostname': inventory_hostname, 'tags': tags if tags is defined else {}, 'cdp': nso_command_output} }}"
+
+    - name: Create device list with CDP data
+      set_fact:
+        devices: "{{ groups['network'] | map('extract', hostvars, 'cdp_data') | list }}"
+      run_once: yes
+
+    - name: Generate topology
+      ciscops.mdd.cml_lab:
+        devices: "{{ devices }}"
+        start_from: "{{ start_from }}"
+      register: results
+      run_once: yes
+
+    - name: "Layout graph using the {{ layout }} layout"
+      set_fact:
+        topology: "{{ results.topology | ciscops.mdd.graph(layout=layout) }}"
+      run_once: yes
+      when: not layout == 'none'
+
+    - name: Create topology file
+      copy:
+        content: "{{ topology | to_nice_yaml(indent=2,sort_keys=False) }}"
+        dest: "{{ lookup('env', 'PWD') }}/files/cml_lab.yaml"
+      run_once: yes
+      no_log: yes
+
+    - name: Create mapping file
+      copy:
+        content: "{{ {'all': {'hosts': results.mappings}} | to_nice_yaml(indent=2,sort_keys=False) }}"
+        dest: "{{ lookup('env', 'PWD') }}/inventory/cml_intf_map.yml"
+      run_once: yes

--- a/playbooks/cml_update_lab.yml
+++ b/playbooks/cml_update_lab.yml
@@ -9,6 +9,7 @@
     start_from: 2
     layout: kamada_kawai
     inventory_dir: inventory
+    scale: 500
   tasks:
 
     - name: Get CDP data
@@ -35,7 +36,7 @@
 
     - name: "Layout graph using the {{ layout }} layout"
       set_fact:
-        topology: "{{ results.topology | ciscops.mdd.graph(layout=layout) }}"
+        topology: "{{ results.topology | ciscops.mdd.graph(layout=layout,scale=500) }}"
       run_once: yes
       when: not layout == 'none'
 

--- a/playbooks/cml_update_lab.yml
+++ b/playbooks/cml_update_lab.yml
@@ -36,7 +36,7 @@
 
     - name: "Layout graph using the {{ layout }} layout"
       set_fact:
-        topology: "{{ results.topology | ciscops.mdd.graph(layout=layout,scale=500) }}"
+        topology: "{{ results.topology | ciscops.mdd.graph(layout=layout,scale=scale) }}"
       run_once: yes
       when: not layout == 'none'
 

--- a/playbooks/cml_update_lab.yml
+++ b/playbooks/cml_update_lab.yml
@@ -11,7 +11,7 @@
     inventory_dir: inventory
     scale: 500
     use_cat9kv: False
-    cml_device_template:
+    default_cml_device_template:
       switch:
         node_definition: iosvl2
         ram: 768
@@ -43,7 +43,7 @@
         ram: 0
         tags: []
     # Default interface mapping for CML
-    cml_default_mappings:
+    default_cml_default_mappings:
       Loopback(\\d+): Loopback\\1
       Vlan(\\d+): Vlan\\1
   tasks:
@@ -62,6 +62,14 @@
       set_fact:
         devices: "{{ groups['network'] | map('extract', hostvars, 'cdp_data') | list }}"
       run_once: yes
+
+    - set_fact:
+        cml_device_template: "{{ default_cml_device_template }}"
+      when: cml_device_template is not defined
+
+    - set_fact:
+        cml_default_mappings: "{{ default_cml_default_mappings }}"
+      when: cml_default_mappings is not defined
 
     - name: Generate topology
       ciscops.mdd.cml_lab:

--- a/playbooks/cml_update_lab.yml
+++ b/playbooks/cml_update_lab.yml
@@ -10,6 +10,42 @@
     layout: kamada_kawai
     inventory_dir: inventory
     scale: 500
+    use_cat9kv: False
+    cml_device_template:
+      switch:
+        node_definition: iosvl2
+        ram: 768
+        tags:
+          - switch
+        type: switch
+      router:
+        node_definition: csr1000v
+        ram: 3072
+        tags:
+          - router
+        type: router
+      # l3switch:
+      #   node_definition: Cat9000v
+      #   image_definition: Cat9k
+      #   ram: 18432
+      #   cpus: 4
+      #   tags:
+      #     - l3switch
+      #   type: l3switch
+      l3switch:
+        node_definition: iosvl2
+        ram: 768
+        tags:
+          - l3switch
+        type: l3switch
+      ext_conn:
+        node_definition: external_connector
+        ram: 0
+        tags: []
+    # Default interface mapping for CML
+    cml_default_mappings:
+      Loopback(\\d+): Loopback\\1
+      Vlan(\\d+): Vlan\\1
   tasks:
 
     - name: Get CDP data
@@ -31,6 +67,9 @@
       ciscops.mdd.cml_lab:
         devices: "{{ devices }}"
         start_from: "{{ start_from }}"
+        device_template: "{{ cml_device_template }}"
+        default_mappings: "{{ cml_default_mappings }}"
+        use_cat9kv: "{{ use_cat9kv | bool }}"
       register: results
       run_once: yes
 

--- a/playbooks/inventory_update_netbox.yml
+++ b/playbooks/inventory_update_netbox.yml
@@ -1,0 +1,35 @@
+- hosts: localhost
+  gather_facts: no
+  roles:
+    - ciscops.mdd.netbox
+  tasks:
+    - include_role:
+        name: ciscops.mdd.netbox
+        tasks_from: netbox_inventory
+
+    - name: Add new device
+      include_role:
+        name: ciscops.mdd.netbox
+        tasks_from: add_device
+      when: inventory_hostname not in netbox_host_list
+      with_items: "{{ groups['network'] }}"
+      vars:
+        netbox_device_name: "{{ hostvars[item].inventory_hostname }}"
+        netbox_device_interface_name: "{{ hostvars[item].mgmt_interface }}"
+        netbox_device_ipv4_address: "{{ hostvars[item].ansible_host }}"
+        netbox_device_type: unknown
+        netbox_device_role: unknown
+
+    - include_role:
+        name: ciscops.mdd.netbox
+        tasks_from: netbox_inventory
+
+    - include_role:
+        name: ciscops.mdd.netbox
+        tasks_from: netbox_mgmt
+      when: hostvars[item].mgmt_interface is defined and hostvars[item].inventory_hostname in netbox_host_list
+      with_items: "{{ groups['network'] }}"
+      vars:
+        netbox_device_name: "{{ hostvars[item].inventory_hostname }}"
+        netbox_device_interface_name: "{{ hostvars[item].mgmt_interface }}"
+        netbox_device_ipv4_address: "{{ hostvars[item].ansible_host }}"

--- a/playbooks/nso_init.yml
+++ b/playbooks/nso_init.yml
@@ -1,5 +1,4 @@
-- hosts: nso
-  connection: local
+- hosts: localhost
   gather_facts: no
   roles:
     - ciscops.mdd.nso

--- a/playbooks/nso_init.yml
+++ b/playbooks/nso_init.yml
@@ -1,7 +1,11 @@
-- hosts: localhost
+- hosts: nso
+  connection: local
   gather_facts: no
   roles:
     - ciscops.mdd.nso
+  vars:
+    ansible_python_interpreter: "{{ hostvars['localhost'].ansible_python_interpreter}}"
+
   tasks:
     - name: Add NSO Auth Groups
       include_role:

--- a/playbooks/nso_update_data.yml
+++ b/playbooks/nso_update_data.yml
@@ -26,6 +26,11 @@
         #     nso_device_config: "{{ nso_device_config | ansible.builtin.combine( { 'config': mdd_data['config'] }, recursive=true) }}"
         #   when: mdd_data['config'] is defined and mdd_data['mdd:openconfig'] is defined
 
+        - name: Translate and truncate interface names
+          set_fact:
+            mdd_data: "{{ mdd_data | ciscops.mdd.intf_xform(cml_intf_xlate) }}"
+          when: (cml_group is defined and cml_group in group_names) and (cml_intf_xlate is defined and cml_intf_xlate)
+
         - name: Update MDD Data
           ansible.builtin.include_role:
             name: ciscops.mdd.nso

--- a/playbooks/nso_update_data.yml
+++ b/playbooks/nso_update_data.yml
@@ -7,7 +7,7 @@
     - ciscops.mdd.data
   vars:
     dry_run: true
-    throttle: 10
+    workers: 10
   tasks:
     - include_role:
         name: ciscops.mdd.nso
@@ -15,7 +15,7 @@
 
     - name: Update OC Data
       when: ('oc' in mdd_data_types)
-      throttle: "{{ throttle }}"
+      throttle: "{{ workers }}"
       block:
         # - name: Combine Device Data with OC Data
         #   ansible.builtin.set_fact:
@@ -42,7 +42,7 @@
 
     - name: Update Config Data
       when: ('config' in mdd_data_types) and not ('oc' in mdd_data_types)
-      throttle: "{{ throttle }}"
+      throttle: "{{ workers }}"
       block:
         - name: Get Device Data
           ansible.builtin.include_role:

--- a/plugins/filter/data.py
+++ b/plugins/filter/data.py
@@ -17,7 +17,7 @@ import re
 list_key_map = {
     "openconfig-network-instance:network-instance$": "openconfig-network-instance:name",
     "openconfig-network-instance:vlan": "openconfig-network-instance:vlan-id",
-    "^mdd:openconfig:openconfig-interfaces:interfaces:openconfig-interfaces:interface": "openconfig-interfaces:name",
+    "^mdd:openconfig:openconfig-interfaces:interfaces:openconfig-interfaces:interface$": "openconfig-interfaces:name",
     ":openconfig-interfaces:interface$": "openconfig-network-instance:id",
     "openconfig-network-instance:static": "openconfig-network-instance:prefix",
     "openconfig-network-instance:protocol": "openconfig-network-instance:name",

--- a/plugins/filter/data.py
+++ b/plugins/filter/data.py
@@ -17,7 +17,7 @@ import re
 list_key_map = {
     "openconfig-network-instance:network-instance": "openconfig-network-instance:name",
     "openconfig-network-instance:vlan": "openconfig-network-instance:vlan-id",
-    "^openconfig-interfaces:interfaces:openconfig-interfaces:interface": "openconfig-interfaces:name",
+    "^mdd:openconfig:openconfig-interfaces:interfaces:openconfig-interfaces:interface": "openconfig-interfaces:name",
     ":openconfig-interfaces:interface$": "openconfig-network-instance:id",
     "openconfig-network-instance:static": "openconfig-network-instance:prefix",
     "openconfig-network-instance:protocol": "openconfig-network-instance:name",

--- a/plugins/filter/data.py
+++ b/plugins/filter/data.py
@@ -15,7 +15,7 @@ import re
 # the list to a hash, then merge the hash.  If there is not match, the list
 # is replaced.
 list_key_map = {
-    "openconfig-network-instance:network-instance": "openconfig-network-instance:name",
+    "openconfig-network-instance:network-instance$": "openconfig-network-instance:name",
     "openconfig-network-instance:vlan": "openconfig-network-instance:vlan-id",
     "^mdd:openconfig:openconfig-interfaces:interfaces:openconfig-interfaces:interface": "openconfig-interfaces:name",
     ":openconfig-interfaces:interface$": "openconfig-network-instance:id",
@@ -150,7 +150,7 @@ def merge_hash(x, y, path, recursive=True, list_merge='replace'):
         if path == '':
             path = key
         else:
-            path = ":".join([path, key])
+            path = ":".join([str(item) for item in [path, key]])
 
         # if both x's element and y's element are dicts
         # recursively "combine" them or override x's with y's element

--- a/plugins/filter/graph.py
+++ b/plugins/filter/graph.py
@@ -10,8 +10,6 @@ except ImportError as imp_exc:
 else:
     NETWORKX_IMPORT_ERROR = None
 
-# display = Display()
-
 
 def graph(topology_data, layout='kamada_kawai', scale=500):
     if NETWORKX_IMPORT_ERROR:
@@ -24,15 +22,13 @@ def graph(topology_data, layout='kamada_kawai', scale=500):
         g.add_edge(link['n1'], link['n2'])
 
     if layout == 'spring':
-        pos = nx.layout.spring_layout(g, scale=scale)
+        pos = nx.layout.spring_layout(g, scale=int(scale))
     elif layout == 'planar':
-        pos = nx.layout.planar_layout(g, scale=scale)
+        pos = nx.layout.planar_layout(g, scale=int(scale))
     elif layout == 'spectral':
-        pos = nx.layout.spectral_layout(g, scale=scale)
+        pos = nx.layout.spectral_layout(g, scale=int(scale))
     elif layout == 'kamada_kawai':
-        pos = nx.layout.kamada_kawai_layout(g, scale=scale)
-
-    # display.vvvvv(f"{pos}")
+        pos = nx.layout.kamada_kawai_layout(g, scale=int(scale))
 
     for key, value in pos.items():
         for node in topology_data['nodes']:

--- a/plugins/filter/graph.py
+++ b/plugins/filter/graph.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+from ansible.module_utils.six import raise_from
+from ansible.errors import AnsibleError
+try:
+    import networkx as nx
+except ImportError as imp_exc:
+    NETWORKX_IMPORT_ERROR = imp_exc
+else:
+    NETWORKX_IMPORT_ERROR = None
+
+# display = Display()
+
+
+def graph(topology_data, layout='kamada_kawai', scale=500):
+    if NETWORKX_IMPORT_ERROR:
+        raise_from(AnsibleError('networkx must be installed to use this plugin'), NETWORKX_IMPORT_ERROR)
+
+    pos = {}
+    g = nx.Graph()
+
+    for link in topology_data['links']:
+        g.add_edge(link['n1'], link['n2'])
+
+    if layout == 'spring':
+        pos = nx.layout.spring_layout(g, scale=scale)
+    elif layout == 'planar':
+        pos = nx.layout.planar_layout(g, scale=scale)
+    elif layout == 'spectral':
+        pos = nx.layout.spectral_layout(g, scale=scale)
+    elif layout == 'kamada_kawai':
+        pos = nx.layout.kamada_kawai_layout(g, scale=scale)
+
+    # display.vvvvv(f"{pos}")
+
+    for key, value in pos.items():
+        for node in topology_data['nodes']:
+            if node['id'] == key:
+                node['x'] = int(value[0])
+                node['y'] = int(value[1])
+
+    return topology_data
+
+
+class FilterModule(object):
+
+    def filters(self):
+        return {
+            'graph': graph,
+        }

--- a/plugins/filter/intf.py
+++ b/plugins/filter/intf.py
@@ -3,7 +3,7 @@ __metaclass__ = type
 
 import re
 
-# The list of keys that will be searched to see is replacement is needed
+# The list of keys that will be searched to see if replacement is needed
 keys_to_replace = [
     "openconfig-interfaces:name",
     "openconfig-network-instance:id",
@@ -12,16 +12,21 @@ keys_to_replace = [
     "openconfig-system-ext:global-interface-name",
     "openconfig-acl:id",
     "openconfig-acl:interface",
-    "openconfig-system-ext:ssh-source-interface"
+    "openconfig-system-ext:ssh-source-interface",
+    "openconfig-network-instance:interface-id",
+    "openconfig-network-instance:index",
+    "openconfig-network-instance:local-address"
+
 ]
 
 
-def multi_replace_regex(string, replacements, ignore_case=False, first_match=True):
-    for pattern, repl in replacements.items():
-        string, matches = re.subn(pattern, repl, string, flags=re.I if ignore_case else 0)
-        if first_match and matches:
-            return string
-    return string
+def interface_name_replace(original_str, intf_dict):
+    original_str_split = original_str.split(".")
+    
+    if original_str_split[0] in intf_dict:
+        return intf_dict[original_str_split[0]] + (f".{original_str_split[1]}" if len(original_str_split) > 1 else "")
+    
+    return original_str
 
 
 def xlate_value(data, intf_dict):
@@ -29,7 +34,7 @@ def xlate_value(data, intf_dict):
     if isinstance(data, dict):
         for key in data:
             if isinstance(data[key], str) and key in keys_to_replace:
-                data[key] = multi_replace_regex(data[key], intf_dict)
+                data[key] = interface_name_replace(data[key], intf_dict)
             else:
                 xlate_value(data[key], intf_dict)
     elif isinstance(data, list):
@@ -64,33 +69,64 @@ def intf_truncate(data, intf_dict):
         # Truncate interfaces
         if "openconfig-interfaces:interfaces" in oc_data and "openconfig-interfaces:interface" in oc_data["openconfig-interfaces:interfaces"]:
             for interface in oc_data["openconfig-interfaces:interfaces"]["openconfig-interfaces:interface"]:
-                if any(re.match(regex, interface["openconfig-interfaces:name"]) for regex in regex_list):
+                if interface["openconfig-interfaces:name"].split(".")[0] in intf_dict:
                     temp_interface_list.append(interface)
             data_out["mdd:openconfig"]["openconfig-interfaces:interfaces"]["openconfig-interfaces:interface"] = temp_interface_list
 
         # Truncate STP interfaces
         if "openconfig-spanning-tree:stp" in oc_data and "openconfig-spanning-tree:interfaces" in oc_data["openconfig-spanning-tree:stp"]:
             for interface in oc_data["openconfig-spanning-tree:stp"]["openconfig-spanning-tree:interfaces"]["openconfig-spanning-tree:interface"]:
-                if any(re.match(regex, interface["openconfig-spanning-tree:name"]) for regex in regex_list):
+                if interface["openconfig-spanning-tree:name"].split(".")[0] in intf_dict:
                     temp_stp_interface_list.append(interface)
             data_out["mdd:openconfig"]["openconfig-spanning-tree:stp"]["openconfig-spanning-tree:interfaces"]["openconfig-spanning-tree:interface"] = \
                 temp_stp_interface_list
 
-        # Truncate OSPF interfaces
+        # Truncate network instance OSPF interfaces
         if "openconfig-network-instance:network-instances" in oc_data and "openconfig-network-instance:network-instance" in oc_data["openconfig-network-instance:network-instances"]:
-            for instance in oc_data["openconfig-network-instance:network-instances"]["openconfig-network-instance:network-instance"]:
+            for (instance_index, instance) in enumerate(oc_data["openconfig-network-instance:network-instances"]["openconfig-network-instance:network-instance"]):
                 if "openconfig-network-instance:protocols" in instance:
-                    for protocol in instance["openconfig-network-instance:protocols"]:
+                    for (prot_index, protocol) in enumerate(instance["openconfig-network-instance:protocols"]["openconfig-network-instance:protocol"]):
                         if "openconfig-network-instance:ospfv2" in protocol and "openconfig-network-instance:areas" in protocol["openconfig-network-instance:ospfv2"]:
                             temp_ospf_interface_list = []
-                            for area in protocol["openconfig-network-instance:ospfv2"]["openconfig-network-instance:areas"]["openconfig-network-instance:area"]:
+                            for (area_index, area) in enumerate(protocol["openconfig-network-instance:ospfv2"]["openconfig-network-instance:areas"]["openconfig-network-instance:area"]):
                                 if "openconfig-network-instance:interfaces" in area:
                                     for interface in area["openconfig-network-instance:interfaces"]["openconfig-network-instance:interface"]:
-                                        if any(re.match(regex, interface["openconfig-network-instance:id"]) for regex in regex_list):
+                                        if interface["openconfig-network-instance:id"].split(".")[0] in intf_dict:
                                             temp_ospf_interface_list.append(interface)
-                                    data_out["mdd:openconfig"]["openconfig-network-instance:network-instances"]["openconfig-network-instance:network-instance"]["openconfig-network-instance:protocols"][protocol]["openconfig-network-instance:ospfv2"]["openconfig-network-instance:areas"]["openconfig-network-instance:area"][area]["openconfig-network-instance:interfaces"]["openconfig-network-instance:interface"] = temp_ospf_interface_list
+                                    data_out["mdd:openconfig"]["openconfig-network-instance:network-instances"]["openconfig-network-instance:network-instance"][instance_index][
+                                        "openconfig-network-instance:protocols"]["openconfig-network-instance:protocol"][prot_index]["openconfig-network-instance:ospfv2"][
+                                        "openconfig-network-instance:areas"]["openconfig-network-instance:area"][area_index]["openconfig-network-instance:interfaces"][
+                                        "openconfig-network-instance:interface"] = temp_ospf_interface_list
 
         # Truncate network-instance interfaces
+        if "openconfig-network-instance:network-instances" in oc_data and "openconfig-network-instance:network-instance" in oc_data["openconfig-network-instance:network-instances"]:
+            for (instance_index, instance) in enumerate(oc_data["openconfig-network-instance:network-instances"]["openconfig-network-instance:network-instance"]):
+                if "openconfig-network-instance:interfaces" in instance:
+                    temp_instance_interface_list = []
+
+                    for interface in instance["openconfig-network-instance:interfaces"]["openconfig-network-instance:interface"]:
+                        if interface["openconfig-network-instance:id"].split(".")[0] in intf_dict:
+                            temp_instance_interface_list.append(interface)
+
+                    data_out["mdd:openconfig"]["openconfig-network-instance:network-instances"]["openconfig-network-instance:network-instance"][instance_index][
+                        "openconfig-network-instance:interfaces"]["openconfig-network-instance:interface"] = temp_instance_interface_list
+                    
+        # Truncate network-instance MPLS interfaces
+        if "openconfig-network-instance:network-instances" in oc_data and "openconfig-network-instance:network-instance" in oc_data["openconfig-network-instance:network-instances"]:
+            for (instance_index, instance) in enumerate(oc_data["openconfig-network-instance:network-instances"]["openconfig-network-instance:network-instance"]):
+                if (len(instance.get("openconfig-network-instance:mpls", {}).get("openconfig-network-instance:global", {}).get("openconfig-network-instance:interface-attributes", {})
+                        .get("openconfig-network-instance:interface", [])) > 0):
+                    temp_mpls_interface_list = []
+
+                    for interface in instance["openconfig-network-instance:mpls"]["openconfig-network-instance:global"]["openconfig-network-instance:interface-attributes"][
+                        "openconfig-network-instance:interface"]:
+                        if interface["openconfig-network-instance:interface-id"].split(".")[0] in intf_dict:
+                            temp_mpls_interface_list.append(interface)
+
+                    data_out["mdd:openconfig"]["openconfig-network-instance:network-instances"]["openconfig-network-instance:network-instance"][instance_index][
+                        "openconfig-network-instance:mpls"]["openconfig-network-instance:global"]["openconfig-network-instance:interface-attributes"][
+                        "openconfig-network-instance:interface"] = temp_mpls_interface_list
+                        
     return data_out
 
 

--- a/plugins/filter/intf.py
+++ b/plugins/filter/intf.py
@@ -5,9 +5,11 @@ import re
 
 # The list of keys that will be searched to see is replacement is needed
 keys_to_replace = [
-    "name",
-    "id",
-    "interface"
+    "openconfig-interfaces:name",
+    "openconfig-network-instance:id",
+    "openconfig-network-instance:interface",
+    "openconfig-spanning-tree:name",
+    "openconfig-system-ext:global-interface-name"
 ]
 
 
@@ -50,12 +52,26 @@ def intf_truncate(data, intf_dict):
 
     regex_list = intf_dict.keys()
     temp_interface_list = []
+    temp_stp_interface_list = []
     data_out = data.copy()
-    if "openconfig-interfaces:interfaces" in data and "openconfig-interfaces:interface" in data["openconfig-interfaces:interfaces"]:
-        for interface in data["openconfig-interfaces:interfaces"]["openconfig-interfaces:interface"]:
-            if any(re.match(regex, interface["name"]) for regex in regex_list):
-                temp_interface_list.append(interface)
-    data_out["openconfig-interfaces:interfaces"]["openconfig-interfaces:interface"] = temp_interface_list
+
+    if "mdd:openconfig" in data:
+        oc_data = data["mdd:openconfig"]
+        # Truncate interfaces
+
+        if "openconfig-interfaces:interfaces" in oc_data and "openconfig-interfaces:interface" in oc_data["openconfig-interfaces:interfaces"]:
+            for interface in oc_data["openconfig-interfaces:interfaces"]["openconfig-interfaces:interface"]:
+                if any(re.match(regex, interface["openconfig-interfaces:name"]) for regex in regex_list):
+                    temp_interface_list.append(interface)
+            data_out["mdd:openconfig"]["openconfig-interfaces:interfaces"]["openconfig-interfaces:interface"] = temp_interface_list
+        # Truncate STP interfaces
+        if "openconfig-spanning-tree:stp" in oc_data and "openconfig-spanning-tree:interfaces" in oc_data["openconfig-spanning-tree:stp"]:
+            for interface in oc_data["openconfig-spanning-tree:stp"]["openconfig-spanning-tree:interfaces"]["openconfig-spanning-tree:interface"]:
+                if any(re.match(regex, interface["openconfig-spanning-tree:name"]) for regex in regex_list):
+                    temp_stp_interface_list.append(interface)
+            data_out["mdd:openconfig"]["openconfig-spanning-tree:stp"]["openconfig-spanning-tree:interfaces"]["openconfig-spanning-tree:interface"] = \
+                temp_stp_interface_list
+
     return data_out
 
 

--- a/plugins/filter/intf.py
+++ b/plugins/filter/intf.py
@@ -1,8 +1,6 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-import re
-
 # The list of keys that will be searched to see if replacement is needed
 keys_to_replace = [
     "openconfig-interfaces:name",
@@ -22,10 +20,10 @@ keys_to_replace = [
 
 def interface_name_replace(original_str, intf_dict):
     original_str_split = original_str.split(".")
-    
+
     if original_str_split[0] in intf_dict:
         return intf_dict[original_str_split[0]] + (f".{original_str_split[1]}" if len(original_str_split) > 1 else "")
-    
+
     return original_str
 
 
@@ -78,29 +76,36 @@ def intf_truncate(data, intf_dict):
             for interface in oc_data["openconfig-spanning-tree:stp"]["openconfig-spanning-tree:interfaces"]["openconfig-spanning-tree:interface"]:
                 if interface["openconfig-spanning-tree:name"].split(".")[0] in intf_dict:
                     temp_stp_interface_list.append(interface)
-            data_out["mdd:openconfig"]["openconfig-spanning-tree:stp"]["openconfig-spanning-tree:interfaces"]["openconfig-spanning-tree:interface"] = \
-                temp_stp_interface_list
+            (data_out["mdd:openconfig"]["openconfig-spanning-tree:stp"]["openconfig-spanning-tree:interfaces"]
+             ["openconfig-spanning-tree:interface"]) = temp_stp_interface_list
 
         # Truncate network instance OSPF interfaces
-        if "openconfig-network-instance:network-instances" in oc_data and "openconfig-network-instance:network-instance" in oc_data["openconfig-network-instance:network-instances"]:
-            for (instance_index, instance) in enumerate(oc_data["openconfig-network-instance:network-instances"]["openconfig-network-instance:network-instance"]):
+        if "openconfig-network-instance:network-instances" in oc_data and ("openconfig-network-instance:network-instance" in
+                                                                           oc_data["openconfig-network-instance:network-instances"]):
+            for (instance_index, instance) in enumerate(oc_data["openconfig-network-instance:network-instances"]
+                                                        ["openconfig-network-instance:network-instance"]):
                 if "openconfig-network-instance:protocols" in instance:
                     for (prot_index, protocol) in enumerate(instance["openconfig-network-instance:protocols"]["openconfig-network-instance:protocol"]):
-                        if "openconfig-network-instance:ospfv2" in protocol and "openconfig-network-instance:areas" in protocol["openconfig-network-instance:ospfv2"]:
+                        if "openconfig-network-instance:ospfv2" in protocol and ("openconfig-network-instance:areas" in
+                                                                                 protocol["openconfig-network-instance:ospfv2"]):
                             temp_ospf_interface_list = []
-                            for (area_index, area) in enumerate(protocol["openconfig-network-instance:ospfv2"]["openconfig-network-instance:areas"]["openconfig-network-instance:area"]):
+                            for (area_index, area) in enumerate(protocol["openconfig-network-instance:ospfv2"]["openconfig-network-instance:areas"]
+                                                                ["openconfig-network-instance:area"]):
                                 if "openconfig-network-instance:interfaces" in area:
                                     for interface in area["openconfig-network-instance:interfaces"]["openconfig-network-instance:interface"]:
                                         if interface["openconfig-network-instance:id"].split(".")[0] in intf_dict:
                                             temp_ospf_interface_list.append(interface)
-                                    data_out["mdd:openconfig"]["openconfig-network-instance:network-instances"]["openconfig-network-instance:network-instance"][instance_index][
-                                        "openconfig-network-instance:protocols"]["openconfig-network-instance:protocol"][prot_index]["openconfig-network-instance:ospfv2"][
-                                        "openconfig-network-instance:areas"]["openconfig-network-instance:area"][area_index]["openconfig-network-instance:interfaces"][
-                                        "openconfig-network-instance:interface"] = temp_ospf_interface_list
+                                    (data_out["mdd:openconfig"]["openconfig-network-instance:network-instances"]
+                                     ["openconfig-network-instance:network-instance"][instance_index]["openconfig-network-instance:protocols"]
+                                     ["openconfig-network-instance:protocol"][prot_index]["openconfig-network-instance:ospfv2"]
+                                     ["openconfig-network-instance:areas"]["openconfig-network-instance:area"][area_index]
+                                     ["openconfig-network-instance:interfaces"]["openconfig-network-instance:interface"]) = temp_ospf_interface_list
 
         # Truncate network-instance interfaces
-        if "openconfig-network-instance:network-instances" in oc_data and "openconfig-network-instance:network-instance" in oc_data["openconfig-network-instance:network-instances"]:
-            for (instance_index, instance) in enumerate(oc_data["openconfig-network-instance:network-instances"]["openconfig-network-instance:network-instance"]):
+        if "openconfig-network-instance:network-instances" in oc_data and ("openconfig-network-instance:network-instance" in
+                                                                           oc_data["openconfig-network-instance:network-instances"]):
+            for (instance_index, instance) in enumerate(oc_data["openconfig-network-instance:network-instances"]
+                                                        ["openconfig-network-instance:network-instance"]):
                 if "openconfig-network-instance:interfaces" in instance:
                     temp_instance_interface_list = []
 
@@ -108,25 +113,29 @@ def intf_truncate(data, intf_dict):
                         if interface["openconfig-network-instance:id"].split(".")[0] in intf_dict:
                             temp_instance_interface_list.append(interface)
 
-                    data_out["mdd:openconfig"]["openconfig-network-instance:network-instances"]["openconfig-network-instance:network-instance"][instance_index][
-                        "openconfig-network-instance:interfaces"]["openconfig-network-instance:interface"] = temp_instance_interface_list
-                    
+                    (data_out["mdd:openconfig"]["openconfig-network-instance:network-instances"]["openconfig-network-instance:network-instance"]
+                     [instance_index]["openconfig-network-instance:interfaces"]["openconfig-network-instance:interface"]) = temp_instance_interface_list
+
         # Truncate network-instance MPLS interfaces
-        if "openconfig-network-instance:network-instances" in oc_data and "openconfig-network-instance:network-instance" in oc_data["openconfig-network-instance:network-instances"]:
-            for (instance_index, instance) in enumerate(oc_data["openconfig-network-instance:network-instances"]["openconfig-network-instance:network-instance"]):
-                if (len(instance.get("openconfig-network-instance:mpls", {}).get("openconfig-network-instance:global", {}).get("openconfig-network-instance:interface-attributes", {})
+        if "openconfig-network-instance:network-instances" in oc_data and ("openconfig-network-instance:network-instance" in
+                                                                           oc_data["openconfig-network-instance:network-instances"]):
+            for (instance_index, instance) in enumerate(oc_data["openconfig-network-instance:network-instances"]
+                                                        ["openconfig-network-instance:network-instance"]):
+                if (len(instance.get("openconfig-network-instance:mpls", {})
+                        .get("openconfig-network-instance:global", {})
+                        .get("openconfig-network-instance:interface-attributes", {})
                         .get("openconfig-network-instance:interface", [])) > 0):
                     temp_mpls_interface_list = []
 
-                    for interface in instance["openconfig-network-instance:mpls"]["openconfig-network-instance:global"]["openconfig-network-instance:interface-attributes"][
-                        "openconfig-network-instance:interface"]:
+                    for interface in (instance["openconfig-network-instance:mpls"]["openconfig-network-instance:global"]
+                                      ["openconfig-network-instance:interface-attributes"]["openconfig-network-instance:interface"]):
                         if interface["openconfig-network-instance:interface-id"].split(".")[0] in intf_dict:
                             temp_mpls_interface_list.append(interface)
 
-                    data_out["mdd:openconfig"]["openconfig-network-instance:network-instances"]["openconfig-network-instance:network-instance"][instance_index][
-                        "openconfig-network-instance:mpls"]["openconfig-network-instance:global"]["openconfig-network-instance:interface-attributes"][
-                        "openconfig-network-instance:interface"] = temp_mpls_interface_list
-                        
+                    (data_out["mdd:openconfig"]["openconfig-network-instance:network-instances"]["openconfig-network-instance:network-instance"]
+                     [instance_index]["openconfig-network-instance:mpls"]["openconfig-network-instance:global"]
+                     ["openconfig-network-instance:interface-attributes"]["openconfig-network-instance:interface"]) = temp_mpls_interface_list
+
     return data_out
 
 

--- a/plugins/filter/intf.py
+++ b/plugins/filter/intf.py
@@ -18,18 +18,21 @@ keys_to_replace = [
     "openconfig-network-instance:local-address"
 ]
 
+
 def found_full_match(string, intf_dict):
     for pattern in intf_dict:
-        if bool(re.fullmatch(pattern, string)): return pattern
+        if bool(re.fullmatch(pattern, string)):
+            return pattern
 
     return None
+
 
 def interface_name_replace(original_str, intf_dict):
     pattern = found_full_match(original_str.split(".")[0], intf_dict)
 
     if pattern:
         return re.sub(pattern, intf_dict[pattern], original_str)
-    
+
     return original_str
 
 

--- a/plugins/lookup/netbox_oc.py
+++ b/plugins/lookup/netbox_oc.py
@@ -206,8 +206,8 @@ def get_endpoint(netbox, resource):
         "rirs": {"endpoint": netbox.ipam.rirs},
         "roles": {"endpoint": netbox.ipam.roles},
         "route-targets": {"endpoint": netbox.ipam.route_targets},
-        "secret-roles": {"endpoint": netbox.secrets.secret_roles},
-        "secrets": {"endpoint": netbox.secrets.secrets},
+        # "secret-roles": {"endpoint": netbox.secrets.secret_roles},
+        # "secrets": {"endpoint": netbox.secrets.secrets},
         "services": {"endpoint": netbox.ipam.services},
         "site-groups": {"endpoint": netbox.dcim.site_groups},
         "sites": {"endpoint": netbox.dcim.sites},
@@ -336,11 +336,11 @@ def interfaces_to_oc(interface_data, ipv4_by_intf, fhrp_by_intf):
         # create one
         if interface["description"]:
             interface_description = interface["description"]
-        elif interface["connected_endpoint"] is not None:
-            if interface["connected_endpoint"].get("device"):
-                connected_device = interface["connected_endpoint"]["device"]["display"]
-                connected_port = interface["connected_endpoint"]["display"]
-                interface_description = "{0}:{1}".format(connected_device, connected_port)
+        # elif interface["connected_endpoint"] is not None:
+        #     if interface["connected_endpoint"].get("device"):
+        #         connected_device = interface["connected_endpoint"]["device"]["display"]
+        #         connected_port = interface["connected_endpoint"]["display"]
+        #         interface_description = "{0}:{1}".format(connected_device, connected_port)
         else:
             interface_description = ''
 
@@ -582,8 +582,8 @@ class LookupModule(LookupBase):
             or os.getenv("NETBOX_URL")
         )
         netbox_ssl_verify = kwargs.get("validate_certs", True)
-        netbox_private_key = kwargs.get("private_key")
-        netbox_private_key_file = kwargs.get("key_file")
+        # netbox_private_key = kwargs.get("private_key")
+        # netbox_private_key_file = kwargs.get("key_file")
         netbox_api_filter = kwargs.get("api_filter")
         netbox_device = terms.pop()
         resources = ['interfaces']
@@ -598,14 +598,13 @@ class LookupModule(LookupBase):
             netbox = pynetbox.api(
                 netbox_api_endpoint,
                 token=netbox_api_token if netbox_api_token else None,
-                private_key=netbox_private_key,
-                private_key_file=netbox_private_key_file,
+                # private_key=netbox_private_key,
+                # private_key_file=netbox_private_key_file,
             )
             netbox.http_session = session
         except FileNotFoundError:
             raise AnsibleError(
-                "%s cannot be found. Please make sure file exists."
-                % netbox_private_key_file
+                "File not found. Please make sure file exists."
             )
 
         oc_data = {}
@@ -687,4 +686,4 @@ class LookupModule(LookupBase):
                                     fhrp_group_copy = fhrp_group.copy()
                                     fhrp_by_intf[id][group_id].update(fhrp_group_copy)
                 oc_data.update(interfaces_to_oc(results, ipv4_by_intf, fhrp_by_intf))
-        return oc_data
+        return {"mdd:openconfig": oc_data}

--- a/plugins/modules/cml_lab.py
+++ b/plugins/modules/cml_lab.py
@@ -144,7 +144,7 @@ def add_interfaces_to_topology(topo_node, device_info, physical_interfaces, use_
             "type": "physical"
         })
         counter = 1
-        for i in range(24):
+        for i in range(number_of_interfaces):
             topo_node["interfaces"].append({
                 "id": "i{0}".format(counter + 1),
                 "label": "GigabitEthernet1/0/{0}".format(counter),

--- a/plugins/modules/cml_lab.py
+++ b/plugins/modules/cml_lab.py
@@ -1,0 +1,685 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2017 Cisco and/or its affiliates.
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1', 'status': ['preview'], 'supported_by': 'community'}
+
+
+DOCUMENTATION = r"""
+---
+module: cml_lab
+short_description: Generate a CML lab file from devices in NSO
+description:
+  - Generate a CML lab file from devices in NSO
+author:
+  - Steven Mosher (@stmosher)
+  - Jason King (@jasonkin)
+requirements:
+  - copy
+version_added: '1.2.0'
+options:
+    devices:
+        description: The devices used to build the topology
+        required: true
+        type: list
+        elements: dict
+    ext_conn:
+        description: Whether to add external connectors to lab
+        required: false
+        type: bool
+        default: true
+    start_from:
+        description: Which physical interface to start mapping to simulated interface
+        required: false
+        type: int
+        default: 2
+"""
+
+EXAMPLES = r"""
+- name: Build the topology
+  hosts: localhost
+  gather_facts: no
+  tasks:
+    - name: Build the topology
+      ciscops.mdd.generate_topology:
+        devices: "{{ devices }}"
+      register: topology
+"""
+
+import copy
+from ansible.module_utils.basic import AnsibleModule
+
+interface_types_list = ["Fas", "Ten", "Gig"]
+device_template = {
+    "switch": {
+        "node_definition": "iosvl2",
+        "ram": 768,
+        "tags": ["switch"],
+        "y": 0,
+        "type": "switch"
+    },
+    "router": {
+        "node_definition": "csr1000v",
+        "ram": 3072,
+        "tags": ["router"],
+        "y": 0,
+        "type": "router"
+    },
+    "l3switch": {
+        "node_definition": "Cat9000v",
+        "image_definition": "Cat9k",
+        "ram": 18432,
+        "cpus": 4,
+        "tags": ["l3switch"],
+        "y": 0,
+        "type": "l3switch"
+    },
+    "ext_conn": {
+        "node_definition": "external_connector",
+        "ram": 0,
+        "tags": [],
+        "y": 0
+    },
+}
+
+default_mappings = {
+    "Loopback(\\d+)": "Loopback\\1",
+    "Vlan(\\d+)": "Vlan\\1"
+}
+
+
+def create_node(node_input):
+    device = {
+        "boot_disk_size": 0,
+        "configuration": node_input["configuration"],
+        "cpu_limit": 100,
+        "cpus": node_input.get("cpus", 1),
+        "data_volume": 0,
+        "hide_links": False,
+        "id": node_input["id"],
+        "label": node_input["hostname"],
+        "node_definition": node_input["node_definition"],
+        "ram": node_input["ram"],
+        "tags": node_input["tags"],
+        "x": node_input["x_position"],
+        "y": node_input.get("y_position", 0),
+        "interfaces": [
+            {
+                "id": "i0",
+                "label": "Loopback0",
+                "type": "loopback"
+            }
+        ]
+    }
+    if node_input.get("image_definition"):
+        device["image_definition"] = node_input.get("image_definition")
+    return device
+
+
+def switch_generate_interface(c, m, s):
+    """
+    Increments module and interface numbering for switches using modules of 4 interfaces, e.g.
+        Gig0/0, Gig0/1, Gig0/2, Gig0/3, Gig1/0...
+    :param c: int, interface number
+    :param m: int, module number
+    :param s: int, CML topo slot number
+    :return: tuple, if-counter, module number, slot number
+    """
+    if c == 3:
+        m += 1
+        c = 0
+    else:
+        c += 1
+    s += 1
+    return c, m, s
+
+
+def add_interfaces_to_topology(topo_node, device_info, physical_interfaces):
+    """
+    Adds interfaces to the devices in the CML topology
+    """
+    number_of_interfaces = len(physical_interfaces) + 3  # initial + 2 spares
+    number_of_interfaces += 4 - (number_of_interfaces % 4)  # interfaces come in sets of 4
+    if device_info["type"] == "l3switch":
+        topo_node["interfaces"].append({
+            "id": "i1",
+            "label": "GigabitEthernet0/0",
+            "slot": 0,
+            "type": "physical"
+        })
+        counter = 1
+        for i in range(24):
+            topo_node["interfaces"].append({
+                "id": "i{0}".format(counter + 1),
+                "label": "GigabitEthernet1/0/{0}".format(counter),
+                "slot": counter,
+                "type": "physical"
+            })
+            counter += 1
+    elif device_info["type"] == "switch":
+        slot = 0
+        mod = 0
+        counter = 0
+        if_id = 1
+        for i in range(number_of_interfaces):
+            topo_node["interfaces"].append({
+                "id": "i{0}".format(if_id),
+                "label": "GigabitEthernet{0}/{1}".format(mod, counter),
+                "slot": slot,
+                "type": "physical"
+            })
+            counter, mod, slot = switch_generate_interface(counter, mod, slot)
+            if_id += 1
+    elif device_info["type"] == "router":
+        slot = 0
+        counter = 1
+        for i in range(number_of_interfaces):
+            topo_node["interfaces"].append({
+                "id": "i{0}".format(counter),
+                "label": "GigabitEthernet{0}".format(counter),
+                "slot": slot,
+                "type": "physical"
+            })
+            slot += 1
+            counter += 1
+
+
+def map_physical_interfaces_to_logical_interfaces(topo_node, physical_interfaces, start_from):
+    """
+    Creates a dict of devices with dicts of interfaces with dicts of physical interface names containing dicts of
+    virtual interfaces and ids. Device dict also contains node-id, e.g.
+    {'Router-01': {'interfaces': {'Gig0': {'if-name': 'GigabitEthernet2', 'id': 'i2'},
+    'Gig0/0/0': {'if-name': 'GigabitEthernet3', 'id': 'i3'},
+    'Gig0/0/1': {'if-name': 'GigabitEthernet4', 'id': 'i4'}},
+    'node_id': 'n0'}
+    :param topo_node:
+    :param physical_interfaces:
+    :return: dict
+    """
+    mapping = {}
+
+    # Find mgmt interface and make sure we map that as well
+    for interface in topo_node["interfaces"]:
+        if interface["id"] == "i1":
+            mapping[interface["label"]] = {"if-name": interface["label"], "id": interface["id"]}
+    for i in range(len(physical_interfaces)):
+        mapping[physical_interfaces[i]] = {"if-name": topo_node["interfaces"][start_from + i]["label"],
+                                           "id": topo_node["interfaces"][start_from + i]["id"]}
+    return mapping
+
+
+def cml_topology_create_initial(devices_with_interface_dict, remote_device_info_full, start_from):
+    """
+    Creates CML topology file and adds nodes
+    :param devices_with_interface_dict:
+    :param remote_device_info_full:
+    :return:
+    """
+    mappings = {}
+    topology = {
+        "lab": {
+            "description": "",
+            "notes": "",
+            "title": "generated_lab",
+            "version": "0.1.0"
+        },
+        "links": [],
+        "nodes": []
+    }
+    node_counter = 0
+    x_position = 0
+    for device in devices_with_interface_dict:
+        configs = {
+            "router": '''
+hostname {0}
+!
+vrf definition Mgmt-intf
+ address-family ipv4
+ exit-address-family
+!
+ip domain name mdd.cisco.com
+!
+crypto key generate rsa modulus 2048
+!
+username admin privilege 15 secret 0 admin
+!
+interface GigabitEthernet1
+ vrf forwarding Mgmt-intf
+ ip address dhcp
+ no shutdown
+!
+ip ssh time-out 60
+ip ssh authentication-retries 2
+!
+line con 0
+line aux 0
+line vty 0 4
+ login local
+ transport input ssh
+ exec-timeout 0 0
+ exit
+netconf ssh
+end
+'''.format(device),
+            "switch": '''
+"hostname {0}
+!
+vrf definition Mgmt-intf
+ address-family ipv4
+ exit-address-family
+!
+ip domain name mdd.cisco.com
+!
+crypto key generate rsa modulus 2048
+!
+username admin privilege 15 secret 0 admin
+!
+interface GigabitEthernet0/0
+ no switchport
+ vrf forwarding Mgmt-intf
+ ip address dhcp
+ no shutdown
+!
+interface GigabitEthernet0/1
+ no switchport
+!
+interface GigabitEthernet0/2
+ no switchport
+!
+interface GigabitEthernet0/3
+ no switchport
+!
+interface GigabitEthernet1/0
+ no switchport
+!
+interface GigabitEthernet1/1
+ no switchport
+!
+interface GigabitEthernet1/2
+ no switchport
+!
+interface GigabitEthernet1/3
+ no switchport
+!
+no ip http server
+no ip http secure-server
+ip ssh time-out 60
+ip ssh authentication-retries 2
+!
+line con 0
+line aux 0
+line vty 0 4
+ login local
+ transport input ssh
+ exec-timeout 0 0
+ exit
+ netconf ssh
+ end"
+'''.format(device),
+            "l3switch": '''
+hostname {0}
+!
+vrf definition Mgmt-intf
+!
+ address-family ipv4
+ exit-address-family
+!
+ip domain name mdd.cisco.com
+!
+crypto key generate rsa modulus 2048
+!
+enable secret 0 Xcisco1234
+!
+username admin privilege 15 secret 0 admin
+!
+interface GigabitEthernet0/0
+ no switchport
+ vrf forwarding Mgmt-intf
+ ip address dhcp
+ no shutdown
+!
+interface GigabitEthernet1/0/1-24
+ no switchport
+!
+no ip http server
+no ip http secure-server
+ip ssh time-out 60
+ip ssh authentication-retries 2
+!
+ip ssh version 2
+!
+ip ssh server algorithm mac hmac-sha1 hmac-sha2-256 hmac-sha2-512
+ip ssh server algorithm kex diffie-hellman-group14-sha1
+!
+line con 0
+line aux 0
+line vty 0 4
+ login local
+ transport input ssh
+ exec-timeout 0 0
+ exit
+netconf ssh
+ip routing
+license boot level network-advantage addon dna-advantage
+license boot level network-advantage
+end
+'''.format(device)
+        }
+        device_type = remote_device_info_full.get(device, {}).get("type", "router")
+        device_info = copy.deepcopy(device_template.get(device_type))
+        device_info["hostname"] = device
+        device_info["x_position"] = x_position
+        device_info["id"] = "n{0}".format(node_counter)
+        device_info["configuration"] = configs[device_type]
+        node_counter += 1
+        x_position += 150
+        topo_node = create_node(device_info)
+        add_interfaces_to_topology(topo_node, device_info, devices_with_interface_dict[device])
+        physical_virtual_map = map_physical_interfaces_to_logical_interfaces(topo_node,
+                                                                             devices_with_interface_dict[device],
+                                                                             start_from)
+        mappings.update({device: {"interfaces": physical_virtual_map,
+                                  "node_id": device_info["id"]}})
+        topology["nodes"].append(topo_node)
+
+    return topology, mappings
+
+
+def find_capabilities(device, cdp_line):
+    """
+    Find capabilites advertised from the remote device. Used to find the best CML image
+    :param device:
+    :param cdp_line:
+    :return: dict of {remote_name, {"platform": hw_platform, "type": ("switch", "router", or "l3switch")}
+    """
+    rev = copy.deepcopy(cdp_line)
+    rev.reverse()
+    capabilities = []
+    for r in rev[3:]:
+        if r.isdigit():
+            break
+        else:
+            if r == "R" or r == "S":
+                capabilities.append(r)
+    if "R" in capabilities and "S" in capabilities:
+        # For now, set this to switch.  Once cat9kv is available, set to l3switch
+        # device_type = "l3switch"
+        device_type = "switch"
+    elif "R" in capabilities:
+        device_type = "router"
+    elif "S" in capabilities:
+        device_type = "switch"
+    else:
+        device_type = None
+    platform = cdp_line[-3]
+    return {device: {"platform": platform, "type": device_type}}
+
+
+def parse_cdp_output(cdp_data, dev, devices):
+    """
+    Find local interface, remote name, remote interface, remote platform, remote capabilities
+
+    return tuple
+        [0] links, e.g.
+            [{
+            "router1": "Ten1/2,
+            "router2": "Ten1/1",
+            }]
+        [1]ldict of devices, platform, and capabilities to be used
+        [{"router10": {"platform": "c6509", "type": "l3switch"}}
+    """
+    device_links_list = []
+    device_info = {}
+    cdp_split = cdp_data.split('\r\n')  # split all csv data on carriage returns
+    cdp_split.pop(0)  # RESTCONF results has an extra blank line
+    # Find the first break list index
+    for c, i in enumerate(cdp_split):
+        if len(i.split()) == 0:
+            index = cdp_split.index(i)
+            break
+
+    index = index + 2  # skip to first device name
+
+    # new_list = [a for a in cdp_split[index:]]  # break single csv line into elements
+    new_list = list(cdp_split[index:])  # break single csv line into elements
+
+    for i in new_list:
+        if len(i.split()) == 1 and "." in i.split()[0]:  # a line with only a name
+            remote = i.split('.')[0]
+        elif len(i.split()) == 1:
+            remote = i.split()[0]
+        elif len(i.split()) == 0:  # blank line is end of cdp neighbors
+            break
+        if i.split()[-1] == "eth0":  # not adding hosts
+            pass
+        elif len(i.split()) > 1 and i.split()[1] in interface_types_list:  # in case hostname is in line with data
+            if "." in i.split()[0]:
+                remote = i.split('.')[0]
+            else:
+                remote = i.split()[0]
+            line_list = i.split()
+            local_interface = line_list[1] + line_list[2]
+            remote_interface = line_list[-2] + line_list[-1]
+            # Only add devices that were included in devices list
+            if any(d['hostname'] == remote for d in devices):
+                device_links_list.append({dev['hostname']: local_interface, remote: remote_interface})
+                device_info.update(find_capabilities(remote, line_list))
+        elif len(i.split()) > 1:  # line with data below the device name line
+            line_list = i.split()
+            local_interface = line_list[0] + line_list[1]
+            remote_interface = line_list[-2] + line_list[-1]
+            # Only add devices that were included in devices list
+            if any(d['hostname'] == remote for d in devices):
+                device_links_list.append({dev['hostname']: local_interface, remote: remote_interface})
+                device_info.update(find_capabilities(remote, line_list))
+    return device_links_list, device_info
+
+
+def check_for_and_remove_error_links(dls):
+    """
+    In case there is a case such as this:
+    Router1   Ten 3/4           155              S I   C9300-24P Ten 1/1/4
+    Router1   Ten 3/4           164              S I   C9300-24P Ten 1/1/3
+
+    remove a Ten3/4 since it can't link to two other physical links
+    :param dls: which is the device_links
+    return: dict {"router1": ["Gig1", "Gig2"], "router2": ["Gig1", "Gig2"]]
+    """
+    devices_with_links = {}  # track each devices' interfaces
+    redundant_links_to_remove = []  # redundant links to be removed from device_links
+    for link_full in dls:
+        for device_name in link_full:
+            if device_name not in devices_with_links:
+                devices_with_links[device_name] = []
+            if link_full[device_name] not in devices_with_links[device_name]:
+                devices_with_links[device_name].append(link_full[device_name])
+            else:
+                redundant_links_to_remove.append(link_full)
+    for link_to_del in redundant_links_to_remove:
+        if link_to_del in dls:
+            dls.remove(link_to_del)
+    return devices_with_links
+
+
+def sort_device_interfaces(remote_device_i):
+    for item in remote_device_i:
+        remote_device_i[item].sort()
+
+
+def cml_topology_add_links(topo, maps, d_links):
+    """
+    Add links to CML topology
+    """
+    counter = 0
+    for d_link in d_links:
+        if len(d_link) != 2:
+            # print(
+            #     f"Warning - Link {d_link} contains {len(d_link)} endpoints. Links must have 2 endpoints. This will not be added to the CML topology")
+            continue
+        link_temp = {"id": "l{0}".format(counter)}
+        d_count = 0
+        for k, v in d_link.items():
+            if d_count == 0:
+                link_temp.update({
+                    "n1": maps[k]["node_id"],
+                    "i1": maps[k]["interfaces"][v]["id"],
+                    "label": "{0}<->".format(k)
+                })
+            elif d_count == 1:
+                link_temp.update({
+                    "n2": maps[k]["node_id"],
+                    "i2": maps[k]["interfaces"][v]["id"],
+                })
+                link_temp["label"] = link_temp["label"] + k
+            d_count += 1
+        topo["links"].append(link_temp)
+        counter += 1
+
+
+def extend_naming(short_name):
+    """
+    If necessary, convert CDP short interface type naming to OS full interface type names
+    """
+    if "Gig" in short_name and "GigabitEthernet" not in short_name:
+        short_name = short_name.replace("Gig", "GigabitEthernet")
+    if "Ten" in short_name and "TenGigabitEthernet" not in short_name:
+        short_name = short_name.replace("Ten", "TenGigabitEthernet")
+    if "Fas" in short_name and "FastEthernet" not in short_name:
+        short_name = short_name.replace("Fas", "FastEthernet")
+    return short_name
+
+
+def create_interface_mapping_dict(mappings):
+    """
+    Write interface physical to virtual mappings to YAML file
+    Write interface virtual to physical mappings to YAML file
+    """
+    mapp_p_to_v = {}
+    for k in mappings:
+        temp_dict_p_to_v = {k: {"cml_intf_xlate": {}}}
+        for key, value in mappings[k]["interfaces"].items():
+            temp_dict_p_to_v[k]["cml_intf_xlate"].update({extend_naming(key): value["if-name"]})
+        temp_dict_p_to_v[k]["cml_intf_xlate"].update(default_mappings)
+        mapp_p_to_v.update(temp_dict_p_to_v)
+    return mapp_p_to_v
+
+
+def link_id_start(virtual_topology):
+    links = []
+    for i in virtual_topology["links"]:
+        links.append(int(i["id"].lstrip("l")))
+    links.sort()
+    return links[-1] + 1
+
+
+def node_id_start(virtual_topology):
+    nodes = []
+    for i in virtual_topology["nodes"]:
+        nodes.append(int(i["id"].lstrip("n")))
+    nodes.sort()
+    return nodes[-1] + 1
+
+
+def ext_conn_nodes_create(virtual_topology, draft_topo, node_start):
+    y = -1000
+    for n in draft_topo["nodes"]:
+        device_info = copy.deepcopy(device_template.get("ext_conn"))
+        device_info["label"] = "ext-conn-{0}".format(n['label'])
+        device_info["cpus"] = 0
+        device_info["x"] = 5500
+        device_info["y"] = y
+        device_info["id"] = "n{0}".format(node_start)
+        device_info["configuration"] = "bridge0"
+        device_info["hide_links"] = True
+        device_info["interfaces"] = [{
+            "id": "i0",
+            "label": "port",
+            "slot": 0,
+            "type": "physical"
+        }]
+        virtual_topology["nodes"].append(device_info)
+        y += 50
+        node_start += 1
+
+
+def ext_conn_links_create(virtual_topology, draft_topo, link_node_start, link_start):
+    for n in draft_topo["nodes"]:
+        link = {
+            "id": "l{0}".format(link_start),
+            "n1": n["id"],
+            "i1": "i1",
+            "n2": "n{0}".format(link_node_start),
+            "i2": "i0",
+            "label": "{0}<->ext-conn-{1}".format(n['label'], n['label'])
+        }
+        virtual_topology["links"].append(link)
+        link_start += 1
+        link_node_start += 1
+
+
+def cml_topology_add_external_connectors_and_links(topo):
+    """
+    Add an external connected or link to each node management interface
+    """
+    link_start = link_id_start(topo)
+    node_start = node_id_start(topo)
+    link_node_start = node_start
+    new_topo = copy.deepcopy(topo)
+
+    ext_conn_nodes_create(topo, new_topo, node_start)
+    ext_conn_links_create(topo, new_topo, link_node_start, link_start)
+
+
+def main():
+    arguments = dict(
+        devices=dict(required=True, type='list', elements='dict'),
+        ext_conn=dict(required=False, type='bool', default=True),
+        start_from=dict(required=False, type='int', default=2)
+    )
+
+    module = AnsibleModule(argument_spec=arguments, supports_check_mode=False)
+
+    device_links = []
+    remote_device_info_full = {}
+
+    devices = module.params['devices']
+    start_from = module.params['start_from']
+
+    for device in devices:
+        temp_device_links, remote_device_info = parse_cdp_output(device['cdp'], device, devices)
+        remote_device_info_full.update(remote_device_info)
+        for link in temp_device_links:  # add any newly found links to device links
+            if link not in device_links:
+                device_links.append(link)  # now saved newly discovered links
+    devices_with_interface_dict = check_for_and_remove_error_links(device_links)
+    sort_device_interfaces(devices_with_interface_dict)
+    topology_cml, mappings_cml = cml_topology_create_initial(devices_with_interface_dict, remote_device_info_full, start_from)
+    cml_topology_add_links(topology_cml, mappings_cml, device_links)
+    if module.params['ext_conn']:
+        cml_topology_add_external_connectors_and_links(topology_cml)
+    mappings = create_interface_mapping_dict(mappings_cml)
+
+    module.exit_json(changed=True, topology=topology_cml, mappings=mappings)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/cml_lab.py
+++ b/plugins/modules/cml_lab.py
@@ -144,7 +144,8 @@ def add_interfaces_to_topology(topo_node, device_info, physical_interfaces, use_
             "type": "physical"
         })
         counter = 1
-        for i in range(number_of_interfaces):
+        # cat9kv *requires* that 24 ports be configured for the 24-port version
+        for i in range(24):
             topo_node["interfaces"].append({
                 "id": "i{0}".format(counter + 1),
                 "label": "GigabitEthernet1/0/{0}".format(counter),

--- a/plugins/modules/cml_lab.py
+++ b/plugins/modules/cml_lab.py
@@ -217,13 +217,15 @@ def map_physical_interfaces_to_logical_interfaces(topo_node, physical_interfaces
     """
     mapping = {}
 
-    # Find mgmt interface and make sure we map that as well
-    for interface in topo_node["interfaces"]:
-        if interface["id"] == "i1":
-            mapping[interface["label"]] = {"if-name": interface["label"], "id": interface["id"]}
+    # If start_from > 1, find mgmt interface and make sure we map that as well, otherwise it will be truncated
+    if start_from > 1:
+        for interface in topo_node["interfaces"]:
+            if interface["id"] == "i1":
+                mapping[interface["label"]] = {"if-name": interface["label"], "id": interface["id"]}
+        start_from = start_from - 1
     for i in range(len(physical_interfaces)):
-        mapping[physical_interfaces[i]] = {"if-name": topo_node["interfaces"][start_from + i]["label"],
-                                           "id": topo_node["interfaces"][start_from + i]["id"]}
+        mapping[physical_interfaces[i]] = {"if-name": topo_node["interfaces"][start_from + i + 1]["label"],
+                                           "id": topo_node["interfaces"][start_from + i + 1]["id"]}
     return mapping
 
 

--- a/plugins/modules/cml_lab.py
+++ b/plugins/modules/cml_lab.py
@@ -337,7 +337,76 @@ interface GigabitEthernet0/0
  ip address dhcp
  no shutdown
 !
-interface GigabitEthernet1/0/1-24
+interface GigabitEthernet1/0/1
+ no switchport
+!
+interface GigabitEthernet1/0/2
+ no switchport
+!
+interface GigabitEthernet1/0/3
+ no switchport
+!
+interface GigabitEthernet1/0/4
+ no switchport
+!
+interface GigabitEthernet1/0/5
+ no switchport
+!
+interface GigabitEthernet1/0/6
+ no switchport
+!
+interface GigabitEthernet1/0/7
+ no switchport
+!
+interface GigabitEthernet1/0/8
+ no switchport
+!
+interface GigabitEthernet1/0/9
+ no switchport
+!
+interface GigabitEthernet1/0/10
+ no switchport
+!
+interface GigabitEthernet1/0/11
+ no switchport
+!
+interface GigabitEthernet1/0/12
+ no switchport
+!
+interface GigabitEthernet1/0/13
+ no switchport
+!
+interface GigabitEthernet1/0/14
+ no switchport
+!
+interface GigabitEthernet1/0/15
+ no switchport
+!
+interface GigabitEthernet1/0/16
+ no switchport
+!
+interface GigabitEthernet1/0/17
+ no switchport
+!
+interface GigabitEthernet1/0/18
+ no switchport
+!
+interface GigabitEthernet1/0/19
+ no switchport
+!
+interface GigabitEthernet1/0/20
+ no switchport
+!
+interface GigabitEthernet1/0/21
+ no switchport
+!
+interface GigabitEthernet1/0/22
+ no switchport
+!
+interface GigabitEthernet1/0/23
+ no switchport
+!
+interface GigabitEthernet1/0/24
  no switchport
 !
 no ip http server

--- a/roles/check/tasks/cli_parse.yml
+++ b/roles/check/tasks/cli_parse.yml
@@ -3,6 +3,7 @@
     command: "{{ check_command }}"
     parser:
         name: ansible.netcommon.pyats
+        command: "{{ parser_command | default(omit) }}"
   connection: network_cli
   register: cli_parse_results
 

--- a/roles/nso/defaults/main.yml
+++ b/roles/nso/defaults/main.yml
@@ -29,3 +29,25 @@ nso_package_repos:
     repo: https://github.com/model-driven-devops/nso-oc-services.git
     service_list:
       - mdd
+nso_global_settings:
+  ssh-algorithms:
+    public-key:
+      - ssh-ed25519
+      - ecdsa-sha2-nistp256
+      - ecdsa-sha2-nistp384
+      - ecdsa-sha2-nistp521
+      - rsa-sha2-512
+      - rsa-sha2-256
+      - ssh-rsa
+      - ssh-dss
+    cipher:
+      - aes128-gcm@openssh.com
+      - AEAD_AES_128_GCM
+      - chacha20-poly1305@openssh.com
+      - aes256-gcm@openssh.com
+      - AEAD_AES_256_GCM
+      - aes128-ctr
+      - aes192-ctr
+      - aes256-ctr
+      - aes128-cbc
+      - 3des-cbc

--- a/roles/nso/tasks/add_auth_groups.yml
+++ b/roles/nso/tasks/add_auth_groups.yml
@@ -12,16 +12,14 @@
               remote-name: "{{ item.value.remote_name }}"
               remote-password: "{{ item.value.remote_password }}"
   loop: "{{ nso_auth_groups | dict2items }}"
+  no_log: true
 
-- name: Allow Older KEX Devices
+- name: Configure global settings
   cisco.nso.nso_config:
     url: "{{ nso_url }}"
     username: "{{ nso_username }}"
     password: "{{ nso_password }}"
     data:
       tailf-ncs:devices:
-        global-settings:
-          ssh-algorithms:
-            public-key:
-              - 'ssh-rsa'
+        global-settings: "{{ nso_global_settings }}"
   register: nso_config_results

--- a/roles/nso/tasks/get_cdp.yml
+++ b/roles/nso/tasks/get_cdp.yml
@@ -1,0 +1,9 @@
+- name: Get CDP data
+  include_role:
+    name: ciscops.mdd.nso
+    tasks_from: exec_command
+  vars:
+    nso_exec_command: show cdp neighbors
+
+- set_fact:
+    devices: "{{ (devices | default([])) + [{'hostname': inventory_hostname, 'tags': tags if tags is defined else {}, 'cdp': nso_command_output}] }}"

--- a/roles/nso/tasks/install_packages.yml
+++ b/roles/nso/tasks/install_packages.yml
@@ -38,6 +38,8 @@
             dest: "/tmp/{{ item.name }}"
           loop: "{{ nso_package_repos }}"
           connection: local
+          vars:
+            ansible_python_interpreter: "{{ hostvars['localhost'].ansible_python_interpreter}}"
 
         - name: Synchronize models to packages directory
           ansible.posix.synchronize:

--- a/roles/nso/tasks/update_yaml_data.yml
+++ b/roles/nso/tasks/update_yaml_data.yml
@@ -4,7 +4,7 @@
 
 - name: Write Config Data to Device Directory
   copy:
-    content: "{{ data | to_nice_yaml(indent=2,sort_keys=False) }}"
+    content: "---\n{{ data | to_nice_yaml(indent=2,sort_keys=False) }}"
     dest: "{{ mdd_device_dir }}/config-data.yml"
   vars:
     data: "{{ { 'mdd_data': { 'config': nso_device_config['config'] } } }}"
@@ -17,7 +17,7 @@
 
   - name: Write OC Data to Device Directory
     copy:
-      content: "{{ data | to_nice_yaml(indent=2,sort_keys=False) }}"
+      content: "---\n{{ data | to_nice_yaml(indent=2,sort_keys=False) }}"
       dest: "{{ mdd_device_dir }}/oc-{{ (item.key | ansible.builtin.split(':'))[1] }}.yml"
     with_dict: "{{ oc_data['mdd_data']['mdd:openconfig'] }}"
     vars:
@@ -25,7 +25,7 @@
     
   - name: Write Native Data to Device Directory
     copy:
-      content: "{{ data | to_nice_yaml(indent=2,sort_keys=False) }}"
+      content: "---\n{{ data | to_nice_yaml(indent=2,sort_keys=False) }}"
       dest: "{{ mdd_device_dir }}/config-remaining.yml"
     vars:
       data: "{{ { 'mdd_data': { 'config': oc_data['mdd_data']['config'] } } }}"

--- a/roles/nso/templates/update-report.yml.j2
+++ b/roles/nso/templates/update-report.yml.j2
@@ -22,5 +22,5 @@
 consolidated_report:
 {% for entry in consolidated_report %}
   - hosts: "{{ entry.hosts }}"
-    data: "{{ entry.data }}"
+    data: '{{ entry.data }}'
 {% endfor %}


### PR DESCRIPTION
* Added playbook `cml_update_lab` for producing CML test topology
* Added playbook `inventory_update_netbox` to update NetBox from Ansible inventory data
* Added `workers` var to update playbook that manages concurrency and avoids bug in OC service on NSO 6.x
* Added interface translate/truncate to update playbook
* Added graph filter to layout CML topology in x,y coordinates
* Fixes to MDD combine filter for list identification
* Updated for interface translation filter for new lists
* Updated `netbox_oc` filer for sandbox NetBox version
* Added `cml_lab` module for generating a CML lab using NSO data
* Updated `data_validation` module for Draft202012Validator
* Allowed `nso_global_settings` to be set in inventory data (ie. for allowed SSH algorithms