### PR TITLE
Updates for working with proxies in NSO

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ namespace: ciscops
 name: mdd
 
 # The version of the collection. Must be compatible with semantic versioning
-version: 1.2.13
+version: 1.2.14
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/roles/nso/tasks/add_auth_groups.yml
+++ b/roles/nso/tasks/add_auth_groups.yml
@@ -11,6 +11,7 @@
             default-map:
               remote-name: "{{ item.value.remote_name }}"
               remote-password: "{{ item.value.remote_password }}"
+              remote-secondary-password: "{{ item.value.remote_secondary_password | default(omit)}}"
   loop: "{{ nso_auth_groups | dict2items }}"
   no_log: true
 

--- a/roles/nso/tasks/add_host.yml
+++ b/roles/nso/tasks/add_host.yml
@@ -10,6 +10,7 @@
           description: CONFIGURED BY ANSIBLE!
           name: "{{ device_name | default(inventory_hostname) }}"
           authgroup: "{{ nso_auth_group | default('default') }}"
+          ned-settings: "{{ ned_settings | default(omit) }}"
           device-type:
             cli:
               ned-id: "{{ device_ned | default(nso_default_ned) }}"


### PR DESCRIPTION
- Added option to specify remote secondary when defining an auth group
- Added option to specify NED settings when adding host to NSO

Example of adding a proxy to the NED settings for a host:

```
              hosts:
                rtr01:
                  ansible_host: 192.168.1.254
                  ned_settings:
                    tailf-ned-cisco-ios-meta:cisco-ios:
                      proxy:
                        remote-connection: ssh
                        remote-address: 10.0.0.200
                        remote-port: 22
                        authgroup: my_auth_group
                        proxy-prompt: ".*$"
```